### PR TITLE
Bugfix for control set of 1 sample

### DIFF
--- a/R/process.R
+++ b/R/process.R
@@ -72,7 +72,13 @@ setMethod("CNV.fit", signature(query = "CNV.data", ref = "CNV.data", anno = "CNV
         }
         object@anno <- anno
         
-        r <- cor(query@intensity[p, ], ref@intensity[p, ])[1, ] < 0.99
+        r <- cor(query@intensity[p, ], ref@intensity[p, ])
+        # cor returns numeric if 1x1, matrix otherwise...
+        if (!is.matrix(r)){ 
+            r <- as.matrix(r)
+            colnames(r) <- colnames(ref@intensity)
+        }
+        r <- r[1, ] < 0.99
         if (any(!r)) message("query sample seems to also be in the reference set. not used for fit.")
         if (intercept) {
             ref.fit <- lm(y ~ ., data = data.frame(y = query@intensity[p, 


### PR DESCRIPTION
cor() returns numeric if given 2 vectors, but matrix if given a vector and a matrix.
This causes CNV.fit to throw an error when given a ref MethylSet containing only one sample:
```
Error in cor(query@intensity[p, ], ref@intensity[p, ])[1, ] :
  incorrect number of dimensions
```
PR adds logic to detect and convert numeric cor() results to the correct type before continuing.